### PR TITLE
Orbital: Fix customer profile auth/purchase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == Version 1.43.3 (July 18, 2014)
 
 * Netregistry: Use updated URL [bslobodin]
+* Orbital: Fix customer profile auth/purchase
 
 == Version 1.43.1 (May 1, 2014)
 

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -191,7 +191,7 @@ module ActiveMerchant #:nodoc:
           add_creditcard(xml, creditcard, options[:currency])
           add_address(xml, creditcard, options)
           if @options[:customer_profiles]
-            add_customer_data(xml, options)
+            add_customer_data(xml, creditcard, options)
             add_managed_billing(xml, options)
           end
         end
@@ -204,7 +204,7 @@ module ActiveMerchant #:nodoc:
           add_creditcard(xml, creditcard, options[:currency])
           add_address(xml, creditcard, options)
           if @options[:customer_profiles]
-            add_customer_data(xml, options)
+            add_customer_data(xml, creditcard, options)
             add_managed_billing(xml, options)
           end
         end
@@ -296,12 +296,14 @@ module ActiveMerchant #:nodoc:
         authorization.split(';')
       end
 
-      def add_customer_data(xml, options)
+      def add_customer_data(xml, creditcard, options)
         if options[:profile_txn]
           xml.tag! :CustomerRefNum, options[:customer_ref_num]
         else
           if options[:customer_ref_num]
-            xml.tag! :CustomerProfileFromOrderInd, USE_CUSTOMER_REF_NUM
+            if creditcard
+              xml.tag! :CustomerProfileFromOrderInd, USE_CUSTOMER_REF_NUM
+            end
             xml.tag! :CustomerRefNum, options[:customer_ref_num]
           else
             xml.tag! :CustomerProfileFromOrderInd, AUTO_GENERATE

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -279,6 +279,26 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_dont_send_customer_profile_from_order_ind_for_profile_purchase
+    @gateway.options[:customer_profiles] = true
+    response = stub_comms do
+      @gateway.purchase(50, nil, :order_id => 1, :customer_ref_num => @customer_ref_num)
+    end.check_request do |endpoint, data, headers|
+      assert_no_match(/<CustomerProfileFromOrderInd>/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+  def test_dont_send_customer_profile_from_order_ind_for_profile_authorize
+    @gateway.options[:customer_profiles] = true
+    response = stub_comms do
+      @gateway.authorize(50, nil, :order_id => 1, :customer_ref_num => @customer_ref_num)
+    end.check_request do |endpoint, data, headers|
+      assert_no_match(/<CustomerProfileFromOrderInd>/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
   def test_currency_code_and_exponent_are_set_for_profile_purchase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do


### PR DESCRIPTION
This commit should fix an issue when authorize/purchase calls were failing with error:

```
<ProcStatus>841</ProcStatus>
<StatusMsg>Error validating card/account number range</StatusMsg>
<ProfileProcStatus>9576</ProfileProcStatus>
<CustomerProfileMessage>Profile: Unable to Perform Profile Transaction. The Associated Transaction Failed. </CustomerProfileMessage>
```

when they are made using stored customer profiles.

[Orbital Gateway XML Interface Specification](https://secure.paymentech.com/developercenter/catalog/files/file?fid=%0A56O7b2gvI%2Bg%3D%0A) specifies:

> When using a Profile, set this field to `EMPTY` or nill-fill:
> `<CustomerProfileFromOrderInd>EMPTY</CustomerProfileFromOrderInd>`

Closes #1370.
